### PR TITLE
Avoid parsing proxy configuration globally

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -9,15 +9,14 @@ accordance with the terms of the Adobe license agreement accompanying
 it.
 */
 
-const path = require('path');
 const shell = require('shelljs');
 const proxy = require('../lib/proxy');
-const proxyConfig = require('../lib/proxyConfig');
 
 require('yargs')
   .scriptName('aem-site-theme-builder')
   .usage('$0 <cmd> [args]')
   .command('live', 'Runs live preview of your theme with content from AEM', (yargs) => {}, function (argv) {
+    const proxyConfig = require('../lib/proxyConfig');
     proxy(proxyConfig);
   })
   .command('deploy', 'Deploys your theme to AEM instance', (yargs) => {}, function (argv) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "aem-site-theme-builder",
+  "name": "@adobe/aem-site-theme-builder",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Avoid parsing proxy configuration globally

## Description

The proxy parses its config globally even when not used breaking the deploy script

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
