### PR TITLE
Align to new url pattern

### DIFF
--- a/lib/proxyConfig.js
+++ b/lib/proxyConfig.js
@@ -20,11 +20,11 @@ module.exports = {
   url: normalizeUrl(url),
   css: {
     "dist": "./dist/css/theme.css",
-    "url": `/conf/${env.SITE}/settings/wcm/clientlibs/theme.*.css`
+    "url": `/content/${env.SITE}.theme/.*/css/theme.css`
   },
   js: {
     "dist": "./dist/js/theme.js",
-    "url": `/conf/${env.SITE}/settings/wcm/clientlibs/theme.*.js`
+    "url": `/content/${env.SITE}.theme/.*/js/theme.js`
   },
   port: `${env.AEM_SITE_PROXY_PORT}`
 };


### PR DESCRIPTION
Fix that maps URLs correctly. We forgot to move it over to new package.

See: https://github.com/gabrielwalt/aem-sites-template-basic/blob/3b98f1150d898a5eee652ba698e60eddc4ec7a65/site.theme/proxy.config.js
