### PR TITLE
cut query string from request url in proxy mapping

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -109,8 +109,8 @@ const proxy = async function (CONFIG) {
   app.use(
     function (req, res) {
       const files = listFiles(CONFIG.dir);
-      // make request path relative by removing /
-      const reqUrl = path.normalize(req.url).slice(1);
+      // Remove / and query string from request url
+      const reqUrl = path.normalize(req.url).slice(1).split('?')[0];
 
       // Prepare route map requestUrl => localFilePath
       const routeMap = new Map(files.reduce((acc, file) => [...acc, [path.relative(CONFIG.dir, file), file]], []));


### PR DESCRIPTION
Fixes issue with browsersync by providing request url without query string to the proxy mapping.