### PR TITLE
feat: support local development access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ AEM_PROXY_PORT=<localhost proxy server port>
 Here is the list of optional variables:
 
 ```
+AEM_TOKEN=<AEM local development access token>
 AEM_ADAPTIVE_FORM=<name of the AEM Form>
 ```
+
+To generate a local development access token, please read the [documentation](https://experienceleague.adobe.com/docs/experience-manager-learn/getting-started-with-aem-headless/authentication/local-development-access-token.html).
 
 Recommended way to define site variables is to use / create `.env` file within your theme project repository.
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -22,7 +22,7 @@ const proxy = async function (CONFIG) {
   const error = msg => console.error(`${prefix} ${msg}`);
 
   // Create proxy server
-  const proxy = httpProxy.createProxyServer({
+  const proxyConfig = {
     target: CONFIG.url,
     secure: false,
     autoRewrite: true,
@@ -34,7 +34,13 @@ const proxy = async function (CONFIG) {
       Referer: CONFIG.url,
       Origin: CONFIG.url
     }
-  });
+  };
+
+  if (CONFIG.token) {
+    proxyConfig.headers.Authorization = 'Bearer ' + CONFIG.token;
+  }
+
+  const proxy = httpProxy.createProxyServer(proxyConfig);
 
   // Modify proxy response
   proxy.on('proxyRes', function (proxyRes, req, res) {

--- a/lib/proxyConfig.js
+++ b/lib/proxyConfig.js
@@ -20,5 +20,6 @@ function normalizeUrl (url) {
 module.exports = {
   url: normalizeUrl(url),
   port: env.AEM_PROXY_PORT,
-  dir: 'dist'
+  dir: 'dist',
+  token: env.AEM_TOKEN
 };


### PR DESCRIPTION
See https://experienceleague.adobe.com/docs/experience-manager-learn/getting-started-with-aem-headless/authentication/local-development-access-token.html?lang=en